### PR TITLE
fix typos, fixes #8

### DIFF
--- a/_posts/2025-03-15-development-diary.md
+++ b/_posts/2025-03-15-development-diary.md
@@ -6,10 +6,10 @@ categories: jekyll update
 ---
 
 # Development Journal
-# Universal Washing Machine Conrtol
+# Universal Washing Machine Control
 
 ## 1 Introduction 
-This is the development jounal for an open source/hardware washing machine control. It shall help to repair an old washing machine for which there are no spare parts available or update a more current modell to more connectivity functions to as to use cheap electricity tarrifs with an WIFI internet connection.
+This is the development journal for an open source/hardware washing machine control. It shall help to repair an old washing machine for which there are no spare parts available or update a more current model to more connectivity functions to as to use cheap electricity tariffs with a WiFi internet connection.
 
 
 
@@ -26,35 +26,35 @@ This is the development jounal for an open source/hardware washing machine contr
 
 ## 3 Components
 ### 3.1 power supply
-Convential washing machines without a converter drive have the following three power levels:
+Conventional washing machines without a converter drive have the following three power levels:
 - 230-V-Level for Motor, Heating and Valves directly connected to the power plug (+electric filters and fuses)
-- 12-V-Level for the relais control elememts
+- 12-V-Level for the relay control elements
 - 3.3-V-Level for the microcontroller
   
 #### 3.1.1 230 V-Level
 Fuse, Filter to reduce EMC levels of the universal motor
 
 ### 3.1.2 12-V-Level
-The 12 V will be provided by a separat power supply unit. This will make the control more robust overall. The power functionalty of the power supply unit can be checked easily by a multimeter. It can be purchased or taken from an old PC. The latter one would also provide 5 V which is used for the 3.3 V. Alternatively almost every smartphone charger can provide the 5V and 500 mA easily.
+The 12 V will be provided by a separat power supply unit. This will make the control more robust overall. The power functionality of the power supply unit can be checked easily by a multimeter. It can be purchased or taken from an old PC. The latter one would also provide 5 V which is used for the 3.3 V. Alternatively almost every smartphone charger can provide the 5V and 500 mA easily.
 
 #### 3.1.3 3.3-V-Level
 The stabilized power supply of 3.3 V for the microcontroller is realized via a linear regulator from 5V.
 
 #### 3.1.4 Zero current switching
-Switching causes trouble and wear. When using a single relais an arc at opening contacts will wear the contacts eventually. Small arcs may even occure while closing when the moving contacts of the relais bounce. The wear and possible weling of the contacts is minimized by putting a thyristor parallel to the relais. This has the following advantages:
+Switching causes trouble and wear. When using a single relay an arc at opening contacts will wear the contacts eventually. Small arcs may even occur while closing when the moving contacts of the relay bounce. The wear and possible weling of the contacts is minimized by putting a thyristor parallel to the relay. This has the following advantages:
 
-- no switching arcs for ON- and OFF-state within the relais
-- minimal thermal losses on the thyristor, because of only one halfwave of current
+- no switching arcs for ON- and OFF-state within the relay
+- minimal thermal losses on the thyristor, because of only one half-wave of current
 
-Every switch event shall be synchronised with net voltage in such a way, that the high loads like motor and heating will be switched on just after the zero crossing of the voltage and switch off at zero current by the thyristor. The reaction time of a relais is usually less than 15 ms so it can easily open during on half cycle of the AC net volatage.
+Every switch event shall be synchronized with net voltage in such a way, that the high loads like motor and heating will be switched on just after the zero crossing of the voltage and switch off at zero current by the thyristor. The reaction time of a relay is usually less than 15 ms so it can easily open during on half cycle of the AC net voltage.
 
 ![frequency detection](/assets/images/frequency-detection.svg)
 
 #### 3.1.5 Frequency detection
 
-The frequency detection serves the time dependent relais switching for minimised wear at the relais contacts. The voltage of an ohmic devider at one end of the secondary winding of the power supply transformer is lead via a diode to an input of the Mikrocontroller. A 2.7...3 V-Zener-Diode protects the input against possible overvoltages.
+The frequency detection serves the time dependent relay switching for minimized wear at the relay contacts. The voltage of an ohmic divider at one end of the secondary winding of the power supply transformer is lead via a diode to an input of the Mikrocontroller. A 2.7...3 V-Zener-Diode protects the input against possible over-voltages.
 
-The ESP has to measure the time difference use it for the determination of the time trigger for the relais. The high load of motor and heat resistor need to be switch on alternative in positiv an negativ halfwave to symmetric loads to the feeding electric network.
+The ESP has to measure the time difference use it for the determination of the time trigger for the relay. The high load of motor and heat resistor need to be switch on alternative in positiv an negativ half-wave to symmetric loads to the feeding electric network.
 
 ### 3.2 Heating - temperature control
 #### 3.3.1 General
@@ -75,10 +75,10 @@ Due to the development goal of achieving the longest possible service life, the 
 
 #### 3.3.2 Physical boundary conditions for heating control
 
-- Water volumen, aprrox.: 10-25 L 
+- Water volume, approx.: 10-25 L 
 - Heat capacity, water: 4,19 kJ/(kg K)
 - Worst case: 90-°C-program, dT=80 K, 10..25 kg → 30...60 min heat period with thermal losses over vat and housing
-- Control with relais: 2-point-control with +/- 1.5 °C sufficient
+- Control with relay: 2-point-control with +/- 1.5 °C sufficient
 - Control via thyristor: Switch-on duration function-related 2 sine half-waves = 20 ms, the thyristors would have to be retriggered every period.
 
 #### 3.4 Motor control
@@ -87,7 +87,7 @@ RPM, direction, tumbling, spinning
 #### 3.5 magnetic valves for cold and hot water
 Electric parameters for valves: 230 V, xxx? A
 
-## 4 Fault identification strathegies
+## 4 Fault identification strategies
 
 Similar to cars, which tell you that i.e. the rear right brake light is defective, the control system should be able to check itself or detect faults in the controlled components.
 
@@ -95,22 +95,22 @@ Similar to cars, which tell you that i.e. the rear right brake light is defectiv
 - The washing drum is a spring-mass oscillator → natural frequency → if a corresponding current harmonic in the motor current is too high, then the damper is worn out.
 
 ### 4.2 main bearing
-- accustic signal via piezzo microphone.
+- acoustic signal via piezo microphone.
 
 ### 4.3 heating
 - no current, broken fuse, earth fault
 
 ### 4.4 main motor
-- no current, then defec carbon brushes 
+- no current, then defected carbon brushes 
 
 ### 4.5 drain pump
 
 ## 5 Question lists
-- 12V vs 24 V bei den Relais? → 12 V is suppost to be cheaper because more common through automotiv.
+- 12V vs 24 V bei den Relais? → 12 V is supposed to be cheaper because more common through automotiv.
 - Relais vs Thyristoren vs SSR?
 
 ## 6 2Do list
-- Frequency detection with capacitive devider
-- Washing programma, times, motor speed for tumbling
+- Frequency detection with capacitive divider
+- Washing programme, times, motor speed for tumbling
 - ECO-Modes: temperature reduction and time extension
-- determination of switch-off times of relais
+- determination of switch-off times of relay


### PR DESCRIPTION
Hey there, me again.

I changed "relais" to "relay". If you meant the plural word (which in german is also written "relais"), then please correct it to "relays". 

Here I wasnt sure: 
```
The wear and possible weling of the contacts 
```

What is "weling" suppost to be? Welding? Tell me and I can correct push it. 

Liebe Grüße!
.Martin